### PR TITLE
fix error when banner disposed before it was loaded

### DIFF
--- a/lib/banner.dart
+++ b/lib/banner.dart
@@ -58,6 +58,12 @@ class _YandexBannerState extends State<YandexBanner> {
   }
 
   @override
+  void dispose(){
+    channel.setMethodCallHandler(null);
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     Widget platformView;
     var creationParams = <String, dynamic>{


### PR DESCRIPTION
Fixes #13 
set banner MethodCallHandler to null in dispose